### PR TITLE
Fix infinite loop with OutOfMemoryException on query in NQuery issue 13

### DIFF
--- a/src/NQuery.Tests/Iterators/TopWithTiesIteratorTests.cs
+++ b/src/NQuery.Tests/Iterators/TopWithTiesIteratorTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Linq;
 
 using NQuery.Iterators;
 
@@ -95,6 +94,20 @@ namespace NQuery.Tests.Iterators
         public void Iterators_TopWithTies_LimitsRows_AndBreaksTies()
         {
             var rows = new object[] {1, 2, 3, 3, 4};
+            var expected = new object[] {1, 2, 3, 3};
+            const int limit = 3;
+
+            using (var input = new MockedIterator(rows))
+            using (var iterator = CreateIterator(input, limit))
+            {
+                AssertProduces(iterator, expected);
+            }
+        }
+
+        [Fact]
+        public void Iterators_TopWithTies_LimitsRows_AndStopsWhenLastRowIsInTie()
+        {
+            var rows = new object[] {1, 2, 3, 3};
             var expected = new object[] {1, 2, 3, 3};
             const int limit = 3;
 

--- a/src/NQuery/Iterators/TopWithTiesIterator.cs
+++ b/src/NQuery/Iterators/TopWithTiesIterator.cs
@@ -32,7 +32,8 @@ namespace NQuery.Iterators
         {
             if (_limitReached)
             {
-                Input.Read();
+                if (!Input.Read())
+                    return false;
             }
             else
             {


### PR DESCRIPTION
When the iterator's last item is part of the tie, every subsequent Read operation would return true instead of false, because the iterator exhaustion wasn't considered in the tie case.