### PR TITLE
Fix bug where LIKE operator treats dots in the match expression as meaning any character

### DIFF
--- a/src/NQuery.Tests/NQuery.Tests.csproj
+++ b/src/NQuery.Tests/NQuery.Tests.csproj
@@ -120,6 +120,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueryTests.cs" />
     <Compile Include="Symbols\BuiltInFunctionsTests.cs" />
+    <Compile Include="Symbols\BuiltInOperatorsTests.cs" />
+    <Compile Include="Symbols\BuiltInSymbolsTests.cs" />
     <Compile Include="Symbols\EumerableTableDefinitionTests.cs" />
     <Compile Include="Syntax\IdentifierTests.cs" />
     <Compile Include="Syntax\LexerTests.cs" />

--- a/src/NQuery.Tests/Symbols/BuiltInFunctionsTests.cs
+++ b/src/NQuery.Tests/Symbols/BuiltInFunctionsTests.cs
@@ -3,15 +3,8 @@ using Xunit;
 
 namespace NQuery.Tests.Symbols
 {
-    public class BuiltInFunctionsTests
+    public class BuiltInFunctionsTests : BuiltInSymbolsTests
     {
-        private static void AssertEvaluatesTo(string text, object expectedValue)
-        {
-            var actualValue = Compute(text);
-
-            Assert.Equal(expectedValue, actualValue);
-        }
-
         private static void AssertEvaluatesToDouble(string text, double expectedValue)
         {
             var untypedActualValue = Compute(text);
@@ -35,13 +28,6 @@ namespace NQuery.Tests.Symbols
         private static DateTime TruncateSeconds(DateTime value)
         {
             return new DateTime(value.Year, value.Month, value.Day, value.Hour, value.Minute, 0);
-        }
-
-        private static object Compute(string text)
-        {
-            var dataContext = DataContext.Default;
-            var expression = Expression<object>.Create(dataContext, text);
-            return expression.Evaluate();
         }
 
         [Fact]

--- a/src/NQuery.Tests/Symbols/BuiltInOperatorsTests.cs
+++ b/src/NQuery.Tests/Symbols/BuiltInOperatorsTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+using Xunit;
+
+namespace NQuery.Tests.Symbols
+{
+    public class BuiltInOperatorsTests : BuiltInSymbolsTests
+    {
+        [Fact]
+        public void BuiltInOperators_Like()
+        {
+            AssertEvaluatesTo("'A' LIKE 'a'", true);
+            AssertEvaluatesTo("'ab' LIKE 'a'", false);
+            AssertEvaluatesTo("'ab' LIKE 'b'", false);
+            AssertEvaluatesTo("'abc' LIKE '_b_'", true);
+            AssertEvaluatesTo("'abcde' LIKE '%c%'", true);
+        }
+    }
+}

--- a/src/NQuery.Tests/Symbols/BuiltInOperatorsTests.cs
+++ b/src/NQuery.Tests/Symbols/BuiltInOperatorsTests.cs
@@ -14,6 +14,7 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("'ab' LIKE 'b'", false);
             AssertEvaluatesTo("'abc' LIKE '_b_'", true);
             AssertEvaluatesTo("'abcde' LIKE '%c%'", true);
+            AssertEvaluatesTo("'2.10.1' LIKE '2.1.%'", false);
         }
     }
 }

--- a/src/NQuery.Tests/Symbols/BuiltInSymbolsTests.cs
+++ b/src/NQuery.Tests/Symbols/BuiltInSymbolsTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+using Xunit;
+
+namespace NQuery.Tests.Symbols
+{
+    public class BuiltInSymbolsTests
+    {
+        protected static void AssertEvaluatesTo(string text, object expectedValue)
+        {
+            var actualValue = Compute(text);
+
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        protected static object Compute(string text)
+        {
+            var dataContext = DataContext.Default;
+            var expression = Expression<object>.Create(dataContext, text);
+            return expression.Evaluate();
+        }
+    }
+}

--- a/src/NQuery/Symbols/BuiltinOperators.cs
+++ b/src/NQuery/Symbols/BuiltinOperators.cs
@@ -39,8 +39,6 @@ namespace NQuery.Symbols
 
         private static bool Like(string str, string expr)
         {
-            str = str.ToUpper(CultureInfo.CurrentCulture);
-
             var sb = new StringBuilder();
 
             sb.Append('^');
@@ -58,14 +56,14 @@ namespace NQuery.Symbols
                         break;
 
                     default:
-                        sb.Append(char.ToUpper(c, CultureInfo.CurrentCulture));
+                        sb.Append(c);
                         break;
                 }
             }
 
             sb.Append('$');
 
-            var r = new Regex(sb.ToString(), RegexOptions.Singleline);
+            var r = new Regex(sb.ToString(), RegexOptions.Singleline | RegexOptions.IgnoreCase);
             return r.IsMatch(str);
         }
 

--- a/src/NQuery/Symbols/BuiltinOperators.cs
+++ b/src/NQuery/Symbols/BuiltinOperators.cs
@@ -39,6 +39,8 @@ namespace NQuery.Symbols
 
         private static bool Like(string str, string expr)
         {
+            expr = Regex.Escape(expr);
+
             var sb = new StringBuilder();
 
             sb.Append('^');


### PR DESCRIPTION
Fixes (old) NQuery issue # 31.