### PR TITLE
Fix issue where the lexer tries to tokenize "10.Equals" as a number

### DIFF
--- a/src/NQuery.Tests/Syntax/ParserTests.Expressions.cs
+++ b/src/NQuery.Tests/Syntax/ParserTests.Expressions.cs
@@ -1178,6 +1178,21 @@ namespace NQuery.Tests.Syntax
             }
         }
 
+        [Fact]
+        public void Parser_Parse_Expression_Literal_WithNumericLiteralWithMemberInvocation()
+        {
+            const string text = @"1.0.EqMethod";
+
+            using (var enumerator = AssertingEnumerator.ForExpression(text))
+            {
+                enumerator.AssertNode(SyntaxKind.PropertyAccessExpression);
+                enumerator.AssertNode(SyntaxKind.LiteralExpression);
+                enumerator.AssertToken(SyntaxKind.NumericLiteralToken, @"1.0");
+                enumerator.AssertToken(SyntaxKind.DotToken, @".");
+                enumerator.AssertToken(SyntaxKind.IdentifierToken, @"EqMethod");
+            }
+        }
+
         [Theory]
         [MemberData("GetContextualKeywords")]
         public void Parser_Parse_Expression_MethodInvocation_WithContextualKeyword(SyntaxKind kind)

--- a/src/NQuery/Syntax/CharReader.cs
+++ b/src/NQuery/Syntax/CharReader.cs
@@ -33,7 +33,7 @@ namespace NQuery.Syntax
             return Peek(1);
         }
 
-        private char Peek(int offset)
+        public char Peek(int offset)
         {
             var index = Position + offset;
             return index < _text.Length

--- a/src/NQuery/Syntax/Lexer.cs
+++ b/src/NQuery/Syntax/Lexer.cs
@@ -514,6 +514,14 @@ namespace NQuery.Syntax
                 {
                     // dot
                     case '.':
+
+                        // "10.Equals" should not be recognized as a number.
+
+                        var peek1 = _charReader.Peek(1);
+                        var peek2 = _charReader.Peek(2);
+                        if ((peek1 == 'e' || peek1 == 'E') && peek2 != '-' && peek2 != '+' && !char.IsDigit(peek2))
+                            goto ExitLoop;
+
                         sb.Append(_charReader.Current);
                         _charReader.NextChar();
                         hasDotModifier = true;


### PR DESCRIPTION
Wrote a parser-based test for this as there are several ways of solving the problem and this is the more general approach for testing.