### PR TITLE
Fix lexing of floating points

### DIFF
--- a/src/NQuery.Tests/Syntax/ParserTests.Expressions.cs
+++ b/src/NQuery.Tests/Syntax/ParserTests.Expressions.cs
@@ -1179,6 +1179,21 @@ namespace NQuery.Tests.Syntax
         }
 
         [Fact]
+        public void Parser_Parse_Expression_Literal_WithNumericLiteralWithMember()
+        {
+            const string text = @"10.Property";
+
+            using (var enumerator = AssertingEnumerator.ForExpression(text))
+            {
+                enumerator.AssertNode(SyntaxKind.PropertyAccessExpression);
+                enumerator.AssertNode(SyntaxKind.LiteralExpression);
+                enumerator.AssertToken(SyntaxKind.NumericLiteralToken, @"10");
+                enumerator.AssertToken(SyntaxKind.DotToken, @".");
+                enumerator.AssertToken(SyntaxKind.IdentifierToken, @"Property");
+            }
+        }
+
+        [Fact]
         public void Parser_Parse_Expression_Literal_WithNumericLiteralWithMemberInvocation()
         {
             const string text = @"1.0.EqMethod";

--- a/src/NQuery/Syntax/Lexer.cs
+++ b/src/NQuery/Syntax/Lexer.cs
@@ -519,7 +519,9 @@ namespace NQuery.Syntax
 
                         var peek1 = _charReader.Peek(1);
                         var peek2 = _charReader.Peek(2);
-                        if ((peek1 == 'e' || peek1 == 'E') && peek2 != '-' && peek2 != '+' && !char.IsDigit(peek2))
+                        var startsFloatingPoint = char.IsDigit(peek1) ||
+                                                  ((peek1 == 'e' || peek1 == 'E') && (peek2 == '+' || peek2 == '-' || char.IsDigit(peek2)));
+                        if (!startsFloatingPoint)
                             goto ExitLoop;
 
                         sb.Append(_charReader.Current);


### PR DESCRIPTION
In #5 we've tried to fix the lexing of floating point numbers when an identifier follows the period. Unfortunately, the condition was still malformed and causes this expression to be lexed as a single number:

```SQL
SELECT 10.GetTypeCode()
```

This should fix that.

/cc @dallmair