### PR TITLE
Fix NOT IN( ... )

### DIFF
--- a/src/NQuery.Tests/Evaluation/EvaluationTest.cs
+++ b/src/NQuery.Tests/Evaluation/EvaluationTest.cs
@@ -1,0 +1,55 @@
+using System;
+using Xunit;
+
+namespace NQuery.Tests.Evaluation
+{
+    public class EvaluationTest
+    {
+        protected void AssertProduces<T>(string text, T[] expected)
+        {
+            var expectedColumns = new[] { typeof(T) };
+            var expectedRows = new object[expected.Length][];
+
+            for (var i = 0; i < expected.Length; i++)
+                expectedRows[i] = new object[] { expected[i] };
+
+            AssertProduces(text, expectedColumns, expectedRows);
+        }
+
+        protected void AssertProduces<T1, T2>(string text, (T1, T2)[] expected)
+        {
+            var expectedColumns = new[] { typeof(T1), typeof(T2) };
+            var expectedRows = new object[expected.Length][];
+
+            for (var i = 0; i < expected.Length; i++)
+                expectedRows[i] = new object[] { expected[i].Item1, expected[i].Item2 };
+
+            AssertProduces(text, expectedColumns, expectedRows);
+        }
+
+        private void AssertProduces(string text, Type[] expectedColumns, object[][] expectedRows)
+        {
+            var dataContext = NorthwindDataContext.Instance;
+            var query = Query.Create(dataContext, text);
+            using (var data = query.ExecuteReader())
+            {
+                Assert.Equal(expectedColumns.Length, data.ColumnCount);
+
+                for (var i = 0; i < expectedColumns.Length; i++)
+                    Assert.Equal(expectedColumns[i], data.GetColumnType(i));
+
+                var rowIndex = 0;
+
+                while (data.Read())
+                {
+                    var expectedRow = expectedRows[rowIndex];
+
+                    for (var columnIndex = 0; columnIndex < expectedColumns.Length; columnIndex++)
+                        Assert.Equal(expectedRow[columnIndex], data[columnIndex]);
+
+                    rowIndex++;
+                }
+            }
+        }
+    }
+}

--- a/src/NQuery.Tests/Evaluation/InExpressionTests.cs
+++ b/src/NQuery.Tests/Evaluation/InExpressionTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Xunit;
+
+namespace NQuery.Tests.Evaluation
+{
+    public class InExpressionTests
+    {
+        private void AssertProduces<T>(string text, T[] expected)
+        {
+            var expectedColumns = new[] { typeof(T) };
+            var expectedRows = new object[expected.Length][];
+
+            for (var i = 0; i < expected.Length; i++)
+                expectedRows[i] = new object[] { expected[i] };
+
+            AssertProduces(text, expectedColumns, expectedRows);
+        }
+
+        private void AssertProduces<T1, T2>(string text, ValueTuple<T1, T2>[] expected)
+        {
+            var expectedColumns = new[] { typeof(T1), typeof(T2) };
+            var expectedRows = new object[expected.Length][];
+
+            for (var i = 0; i < expected.Length; i++)
+                expectedRows[i] = new object[] { expected[i].Item1, expected[i].Item2 };
+
+            AssertProduces(text, expectedColumns, expectedRows);
+        }
+
+        private void AssertProduces(string text, Type[] expectedColumns, object[][] expectedRows)
+        {
+            var dataContext = NorthwindDataContext.Instance;
+            var query = Query.Create(dataContext, text);
+            using (var data = query.ExecuteReader())
+            {
+                Assert.Equal(expectedColumns.Length, data.ColumnCount);
+
+                for (var i = 0; i < expectedColumns.Length; i++)
+                    Assert.Equal(expectedColumns[i], data.GetColumnType(i));
+
+                var rowIndex = 0;
+
+                while (data.Read())
+                {
+                    var expectedRow = expectedRows[rowIndex];
+
+                    for (var columnIndex = 0; columnIndex < expectedColumns.Length; columnIndex++)
+                        Assert.Equal(expectedRow[columnIndex], data[columnIndex]);
+
+                    rowIndex++;
+                }
+            }
+        }
+
+        [Fact]
+        public void Evaluation_InExpression()
+        {
+            var text = @"
+                SELECT  e.EmployeeID
+                FROM    Employees e
+                WHERE   e.EmployeeID NOT IN (1, 2, 3)
+            ";
+
+            var expected = new[] { 4, 5, 6, 7, 8, 9 };
+
+            AssertProduces(text, expected);
+        }
+    }
+}

--- a/src/NQuery.Tests/Evaluation/InQueryExpressionTests.cs
+++ b/src/NQuery.Tests/Evaluation/InQueryExpressionTests.cs
@@ -8,12 +8,19 @@ namespace NQuery.Tests.Evaluation
         public void Evaluation_InQueryExpression()
         {
             var text = @"
-                SELECT  e.EmployeeID
-                FROM    Employees e
-                WHERE   e.EmployeeID IN (SELECT 1 UNION ALL SELECT 8)
+                SELECT	e.EmployeeID,
+                        e.ReportsTo
+                FROM	Employees e
+                WHERE	e.ReportsTo IN (SELECT RegionID FROM Region)
             ";
 
-            var expected = new[] { 1, 8 };
+            var expected = new[] {
+                (1, 2),
+                (3, 2),
+                (4, 2),
+                (5, 2),
+                (8, 2)
+            };
 
             AssertProduces(text, expected);
         }
@@ -22,12 +29,17 @@ namespace NQuery.Tests.Evaluation
         public void Evaluation_InQueryExpression_Negated()
         {
             var text = @"
-                SELECT  e.EmployeeID
-                FROM    Employees e
-                WHERE   e.EmployeeID NOT IN (SELECT 1 UNION ALL SELECT 8)
+                SELECT	e.EmployeeID,
+                        e.ReportsTo
+                FROM	Employees e
+                WHERE	e.ReportsTo NOT IN (SELECT RegionID FROM Region)
             ";
 
-            var expected = new[] { 2, 3, 4, 5, 6, 7, 9 };
+            var expected = new[] {
+                (6, 5),
+                (7, 5),
+                (9, 5)
+            };
 
             AssertProduces(text, expected);
         }

--- a/src/NQuery.Tests/Evaluation/InQueryExpressionTests.cs
+++ b/src/NQuery.Tests/Evaluation/InQueryExpressionTests.cs
@@ -2,32 +2,32 @@ using Xunit;
 
 namespace NQuery.Tests.Evaluation
 {
-    public class InExpressionTests : EvaluationTest
+    public class InQueryExpressionTests : EvaluationTest
     {
         [Fact]
-        public void Evaluation_InExpression()
+        public void Evaluation_InQueryExpression()
         {
             var text = @"
                 SELECT  e.EmployeeID
                 FROM    Employees e
-                WHERE   e.EmployeeID IN (1, 2, 3)
+                WHERE   e.EmployeeID IN (SELECT 1 UNION ALL SELECT 8)
             ";
 
-            var expected = new[] { 1, 2, 3 };
+            var expected = new[] { 1, 8 };
 
             AssertProduces(text, expected);
         }
 
         [Fact]
-        public void Evaluation_InExpression_Negated()
+        public void Evaluation_InQueryExpression_Negated()
         {
             var text = @"
                 SELECT  e.EmployeeID
                 FROM    Employees e
-                WHERE   e.EmployeeID NOT IN (1, 2, 3)
+                WHERE   e.EmployeeID NOT IN (SELECT 1 UNION ALL SELECT 8)
             ";
 
-            var expected = new[] { 4, 5, 6, 7, 8, 9 };
+            var expected = new[] { 2, 3, 4, 5, 6, 7, 9 };
 
             AssertProduces(text, expected);
         }

--- a/src/NQuery/Binding/Binder.Expressions.cs
+++ b/src/NQuery/Binding/Binder.Expressions.cs
@@ -596,7 +596,8 @@ namespace NQuery.Binding
                                    let boundComparision = BindBinaryExpression(a.Span, BinaryOperatorKind.Equal, boundExpression, boundArgument)
                                    select boundComparision;
 
-            return boundComparisons.Aggregate<BoundExpression, BoundExpression>(null, (c, b) => c == null ? b : BindBinaryExpression(node.Span, BinaryOperatorKind.LogicalOr, c, b));
+            var inExpressionsAggregate = boundComparisons.Aggregate<BoundExpression, BoundExpression>(null, (c, b) => c == null ? b : BindBinaryExpression(node.Span, BinaryOperatorKind.LogicalOr, c, b));
+            return BindOptionalNegation(node.Span, node.NotKeyword, inExpressionsAggregate);
         }
 
         private BoundExpression BindInQueryExpression(InQueryExpressionSyntax node)


### PR DESCRIPTION
`[NOT] IN (...)` syntax always translates to an `Equality` expression, while `NOT IN(...)` should actually translate to a `NotEqual` one.