### PR TITLE
Fix NerdBank.GitVersioning references to make it a build-time only dependency

### DIFF
--- a/src/NQuery.Authoring.ActiproWpf/NQuery.Authoring.ActiproWpf.csproj
+++ b/src/NQuery.Authoring.ActiproWpf/NQuery.Authoring.ActiproWpf.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="ActiproSoftware.Shared.Wpf" Version="14.2.0610" />
     <PackageReference Include="ActiproSoftware.SyntaxEditor.Wpf" Version="14.2.0610" />
     <PackageReference Include="ActiproSoftware.Text.Wpf" Version="14.2.0610" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Authoring.Composition/NQuery.Authoring.Composition.csproj
+++ b/src/NQuery.Authoring.Composition/NQuery.Authoring.Composition.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Authoring.VSEditorWpf/NQuery.Authoring.VSEditorWpf.csproj
+++ b/src/NQuery.Authoring.VSEditorWpf/NQuery.Authoring.VSEditorWpf.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.VSEditor.Standalone.10" Version="1.0.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Authoring.Wpf/NQuery.Authoring.Wpf.csproj
+++ b/src/NQuery.Authoring.Wpf/NQuery.Authoring.Wpf.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Authoring/NQuery.Authoring.csproj
+++ b/src/NQuery.Authoring/NQuery.Authoring.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Data/NQuery.Data.csproj
+++ b/src/NQuery.Data/NQuery.Data.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery.Dynamic/NQuery.Dynamic.csproj
+++ b/src/NQuery.Dynamic/NQuery.Dynamic.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 

--- a/src/NQuery/NQuery.csproj
+++ b/src/NQuery/NQuery.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
At the moment, the built packages have a dependency on NerdBank.GitVersioning, which they obviously shouldn't have. Make all assets of said `PackageReference`s private to remove the NuGet package dependency.