### PR TITLE
Ensure SyntaxToken.Parent is never null

### DIFF
--- a/src/NQuery.Authoring/Completion/Providers/KeywordCompletionProvider.cs
+++ b/src/NQuery.Authoring/Completion/Providers/KeywordCompletionProvider.cs
@@ -493,7 +493,7 @@ namespace NQuery.Authoring.Completion.Providers
         private static bool IsBeforeQuery(SyntaxTree syntaxTree, int position)
         {
             var token = syntaxTree.Root.FindToken(position);
-            if (token is not null && token.Kind == SyntaxKind.EndOfFileToken && syntaxTree.Root.Root is QuerySyntax)
+            if (token is not null && token.Kind == SyntaxKind.EndOfFileToken && syntaxTree.Root.Root is not ExpressionSyntax)
                 return true;
 
             return IsBeforeNode<QuerySyntax>(syntaxTree, position);

--- a/src/NQuery.Tests/CompiledQueryTests.cs
+++ b/src/NQuery.Tests/CompiledQueryTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NQuery.Tests
+{
+    public class CompiledQueryTests
+    {
+        [Fact]
+        public void CompiledQuery_Expression_ReturnsNull_ForEmptyQuery()
+        {
+            var dataContext = DataContext.Empty;
+            var syntaxTree = SyntaxTree.ParseQuery(string.Empty);
+            var compilation = Compilation.Create(dataContext, syntaxTree);
+            var compiledQuery = compilation.Compile();
+
+            var expressionEvaluator = compiledQuery.CreateExpressionEvaluator();
+            var value = expressionEvaluator.Evaluate();
+
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void CompiledQuery_Query_ReturnsNoResults_ForEmptyQuery()
+        {
+            var dataContext = DataContext.Empty;
+            var syntaxTree = SyntaxTree.ParseQuery(string.Empty);
+            var compilation = Compilation.Create(dataContext, syntaxTree);
+            var compiledQuery = compilation.Compile();
+
+            var reader = compiledQuery.CreateReader();
+            Assert.Equal(0, reader.ColumnCount);
+            Assert.False(reader.Read());
+        }
+    }
+}

--- a/src/NQuery.Tests/Syntax/SyntaxFactsTests.cs
+++ b/src/NQuery.Tests/Syntax/SyntaxFactsTests.cs
@@ -5,6 +5,37 @@ namespace NQuery.Tests.Syntax
     public class SyntaxFactsTests
     {
         [Fact]
+        public void SyntaxFacts_ParseToken_ReturnsActualToken()
+        {
+            var token = SyntaxFacts.ParseToken("a");
+
+            Assert.Equal(SyntaxKind.IdentifierToken, token.Kind);
+            Assert.Equal("a", token.ValueText);
+            Assert.NotNull(token.Parent.SyntaxTree);
+        }
+
+        [Fact]
+        public void SyntaxFacts_ParseToken_FailsForMultipleTokens()
+        {
+            Assert.Throws<InvalidOperationException>(() => SyntaxFacts.ParseToken("+-"));
+        }
+
+        [Fact]
+        public void SyntaxFacts_ParseTokens_ReturnsMultipleTokens()
+        {
+            var tokens = SyntaxFacts.ParseTokens("+-").ToArray();
+
+            Assert.Equal(3, tokens.Length);
+            Assert.Equal(SyntaxKind.PlusToken, tokens[0].Kind);
+            Assert.Equal(SyntaxKind.MinusToken, tokens[1].Kind);
+            Assert.Equal(SyntaxKind.EndOfFileToken, tokens[2].Kind);
+
+            Assert.NotNull(tokens[0].Parent.SyntaxTree);
+            Assert.NotNull(tokens[1].Parent.SyntaxTree);
+            Assert.NotNull(tokens[2].Parent.SyntaxTree);
+        }
+
+        [Fact]
         public void SyntaxFacts_Keyword_GetKeywords_ReturnsAllKindsNamedKeyword()
         {
             var expectedKeywords = GetAllKindsNamedKeyword().OrderBy(t => t);

--- a/src/NQuery/Binding/Binder.Queries.cs
+++ b/src/NQuery/Binding/Binder.Queries.cs
@@ -331,6 +331,15 @@ namespace NQuery.Binding
             }
         }
 
+        private BoundNode BindEmptyQuery()
+        {
+            var constantRelation = new BoundConstantRelation();
+            var alwaysFalse = new BoundLiteralExpression(false);
+            var filterRelation = new BoundFilterRelation(constantRelation, alwaysFalse);
+            var output = Enumerable.Empty<QueryColumnInstanceSymbol>();
+            return new BoundQuery(filterRelation, output);
+        }
+
         private BoundQuery BindUnionQuery(UnionQuerySyntax node)
         {
             var diagnosticSpan = node.UnionKeyword.Span;

--- a/src/NQuery/Binding/Binder.cs
+++ b/src/NQuery/Binding/Binder.cs
@@ -92,6 +92,9 @@ namespace NQuery.Binding
 
         private BoundNode BindRoot(SyntaxNode root)
         {
+            if (root is null)
+                return BindEmptyQuery();
+
             var query = root as QuerySyntax;
             if (query is not null)
                 return BindQuery(query);

--- a/src/NQuery/CompiledQuery.cs
+++ b/src/NQuery/CompiledQuery.cs
@@ -33,6 +33,10 @@ namespace NQuery
 
         public ExpressionEvaluator CreateExpressionEvaluator()
         {
+            // If the query is empty, just return null
+            if (_query.OutputColumns.Length == 0)
+                return new ExpressionEvaluator(typeof(object), () => null);
+
             var expressionType = _query.OutputColumns.First().ValueSlot.Type;
             var expression = CreateExpression();
             return new ExpressionEvaluator(expressionType, expression);

--- a/src/NQuery/Syntax/CompilationUnitSyntax.cs
+++ b/src/NQuery/Syntax/CompilationUnitSyntax.cs
@@ -16,7 +16,8 @@ namespace NQuery.Syntax
 
         public override IEnumerable<SyntaxNodeOrToken> ChildNodesAndTokens()
         {
-            yield return Root;
+            if (Root is not null)
+                yield return Root;
             yield return EndOfFileToken;
         }
 

--- a/src/NQuery/Syntax/Parser.cs
+++ b/src/NQuery/Syntax/Parser.cs
@@ -255,7 +255,7 @@ namespace NQuery.Syntax
 
         public CompilationUnitSyntax ParseRootQuery()
         {
-            var query = ParseQueryWithOptionalCte();
+            var query = ParseOptionalQueryWithOptionalCte();
             var endOfFileToken = ParseEndOfFileToken();
             return new CompilationUnitSyntax(_syntaxTree, query, endOfFileToken);
         }
@@ -265,6 +265,16 @@ namespace NQuery.Syntax
             var expression = ParseExpression();
             var endOfFileToken = ParseEndOfFileToken();
             return new CompilationUnitSyntax(_syntaxTree, expression, endOfFileToken);
+        }
+
+        public CompilationUnitSyntax ParseRootTokens()
+        {
+            if (Current.Kind != SyntaxKind.EndOfFileToken)
+                SkipTokens(t => t.Kind == SyntaxKind.EndOfFileToken);
+
+            var endOfFileToken = Match(SyntaxKind.EndOfFileToken);
+
+            return new CompilationUnitSyntax(_syntaxTree, null, endOfFileToken);
         }
 
         private SyntaxToken ParseEndOfFileToken()
@@ -737,8 +747,11 @@ namespace NQuery.Syntax
             return new SeparatedSyntaxList<ExpressionSyntax>(expressionsWithCommas);
         }
 
-        private QuerySyntax ParseQueryWithOptionalCte()
+        private QuerySyntax ParseOptionalQueryWithOptionalCte()
         {
+            if (Current.Kind == SyntaxKind.EndOfFileToken)
+                return null;
+
             if (Current.Kind != SyntaxKind.WithKeyword)
                 return ParseQuery();
 

--- a/src/NQuery/SyntaxFacts.cs
+++ b/src/NQuery/SyntaxFacts.cs
@@ -13,9 +13,20 @@ namespace NQuery
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
-            var sourceText = SourceText.From(text);
-            var lexer = new Lexer(null, sourceText);
-            return lexer.Lex();
+            var tokens = ParseTokens(text).ToArray();
+            if (tokens.Length == 1 || tokens.Length == 2)
+                return tokens[0];
+
+            throw new InvalidOperationException($"The text '{text}' produces more than one token.");
+        }
+
+        public static IEnumerable<SyntaxToken> ParseTokens(string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            var syntaxTree = SyntaxTree.ParseTokens(text);
+            return syntaxTree.Root.DescendantTokens(descendIntoTrivia: true);
         }
 
         public static ExpressionSyntax ParseExpression(string text)

--- a/src/NQuery/SyntaxTree.cs
+++ b/src/NQuery/SyntaxTree.cs
@@ -48,6 +48,23 @@ namespace NQuery
             return new SyntaxTree(sourceText, p => p.ParseRootExpression());
         }
 
+        public static SyntaxTree ParseTokens(string source)
+        {
+            if (source is null)
+                throw new ArgumentNullException(nameof(source));
+
+            var textBuffer = SourceText.From(source);
+            return ParseTokens(textBuffer);
+        }
+
+        public static SyntaxTree ParseTokens(SourceText sourceText)
+        {
+            if (sourceText is null)
+                throw new ArgumentNullException(nameof(sourceText));
+
+            return new SyntaxTree(sourceText, p => p.ParseRootTokens());
+        }
+
         public IEnumerable<Diagnostic> GetDiagnostics()
         {
             return from token in Root.DescendantTokens(descendIntoTrivia: true)
@@ -141,10 +158,10 @@ namespace NQuery
             if (newText == Text)
                 return this;
 
-            var isQuery = Root.Root is QuerySyntax;
-            return isQuery
-                ? ParseQuery(newText)
-                : ParseExpression(newText);
+            var isExpression = Root.Root is ExpressionSyntax;
+            return isExpression
+                ? ParseExpression(newText)
+                : ParseQuery(newText);
         }
 
         public static readonly SyntaxTree Empty = ParseQuery(string.Empty);


### PR DESCRIPTION
Right now, we have a path where if you call `SyntaxFacts.ParseToken()` you get back tokens that don't have a parent and thus don't belong to any syntax tree. That is odd. However, lexing a bunch of tokens without parsing them into anything specific is useful, for example, for performance reasons or because you just want a bunch of tokens without any error recovery performed by the parser (e.g. no inserted tokens).

To accommodate that, we allow queries to be empty. We parse an empty query into a `CompilationUnit `whose `Root` property is `null`.

The semantics are:

* Evaluating it as a query will produce zero rows with zero columns.
* Evaluating it as an expression will produce a `null` value (when parsing expressions, we'll still produce a syntax error when the input is empty, but any query can be evaluated as an expression so we have to define this behavior also for expressions).

When parsing individual tokens, we parse them into a `CompilationRoot` whose `Root` property is `null` and all the tokens are contained as leading skipped token trivia for the end-of-file token. Thus, when flattening the tokens it will produce the input sequence but each token still has a defined parent and syntax tree. Also, the returned `SyntaxTree` is valid and can be bound and evaluated with the semantics above.
