### PR TITLE
Fix UnusedValueSlotRemover such that it doesn't eliminate outer references

### DIFF
--- a/src/NQuery.Tests/Evaluation/OuterReferencesTests.cs
+++ b/src/NQuery.Tests/Evaluation/OuterReferencesTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NQuery.Tests.Evaluation
+{
+    public class OuterReferencesTests : EvaluationTest
+    {
+        [Fact]
+        public void OuterReferences_AreNot_Removed()
+        {
+            var text = @"
+                SELECT  (
+                            SELECT  COUNT(*)
+                            FROM    EmployeeTerritories et
+                            WHERE   et.EmployeeID = e.EmployeeID
+                        ) AS TerritoryCount
+                FROM    Employees e
+            ";
+
+            var expected = new[] {
+                2,
+                7,
+                4,
+                3,
+                7,
+                5,
+                10,
+                4,
+                7
+            };
+
+            AssertProduces(text, expected);
+        }
+    }
+}

--- a/src/NQuery/Optimization/UnusedValueSlotRemover.cs
+++ b/src/NQuery/Optimization/UnusedValueSlotRemover.cs
@@ -50,6 +50,10 @@ namespace NQuery.Optimization
             if (node.Probe is not null)
                 _recorder.Record(node.Probe);
 
+            var outerReferences = OuterReferenceFinder.GetOuterReferences(node);
+            foreach (var o in outerReferences)
+                _recorder.Record(o);
+
             return base.RewriteJoinRelation(node);
         }
 


### PR DESCRIPTION
For example, in this snippet

```SQL
SELECT  (
            SELECT  COUNT(*)
            FROM    EmployeeTerritories et
            WHERE   et.EmployeeID = e.EmployeeID
        ) AS TerritoryCount
FROM    Employees e
```

the table scan for `Employees` no longer included `e.EmployeeID`.
