### PR TITLE
Make all built-in functions use invariant culture and add overloads for other cultures

### DIFF
--- a/src/NQuery.Tests/Symbols/BuiltInFunctionsTests.cs
+++ b/src/NQuery.Tests/Symbols/BuiltInFunctionsTests.cs
@@ -1,8 +1,6 @@
-using System.Globalization;
-
 namespace NQuery.Tests.Symbols
 {
-    public class BuiltInFunctionsTests : BuiltInSymbolsTests
+    public sealed class BuiltInFunctionsTests : BuiltInSymbolsTests
     {
         private static void AssertEvaluatesToDouble(string text, double expectedValue)
         {
@@ -123,20 +121,8 @@ namespace NQuery.Tests.Symbols
         [Fact]
         public void BuiltInFunctions_Format()
         {
-            var oldCulture = Thread.CurrentThread.CurrentCulture;
-
-            try
-            {
-                var newCulture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-                newCulture.NumberFormat.PercentSymbol = "#";
-
-                Thread.CurrentThread.CurrentCulture = newCulture;
-                AssertEvaluatesTo("FORMAT(.123, 'P2')", "12.30 #");
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = oldCulture;
-            }
+            AssertEvaluatesTo("FORMAT(.123, 'P2')", "12.30 %");
+            AssertEvaluatesTo("FORMAT(.123, 'P2', 'ar')", "12\u066b30\u066a\u061c");
         }
 
         [Fact]
@@ -187,6 +173,8 @@ namespace NQuery.Tests.Symbols
         public void BuiltInFunctions_Lower()
         {
             AssertEvaluatesTo("LOWER('Hello')", "hello");
+            AssertEvaluatesTo("LOWER('\u0130')", "\u0130");
+            AssertEvaluatesTo("LOWER('\u0130', 'tr-TR')", "i");
         }
 
         [Fact]
@@ -402,6 +390,9 @@ namespace NQuery.Tests.Symbols
 
             AssertEvaluatesTo("TO_BOOLEAN('true')", true);
             AssertEvaluatesTo("TO_BOOLEAN('false')", false);
+
+            AssertEvaluatesTo("TO_BOOLEAN('true', 'de-DE')", true);
+            AssertEvaluatesTo("TO_BOOLEAN('false', 'de-DE')", false);
         }
 
         [Fact]
@@ -409,6 +400,9 @@ namespace NQuery.Tests.Symbols
         {
             AssertEvaluatesTo("TO_BYTE(0)", (byte)0);
             AssertEvaluatesTo("TO_BYTE(255)", (byte)255);
+
+            AssertEvaluatesTo("TO_BYTE('0', 'de-DE')", (byte)0);
+            AssertEvaluatesTo("TO_BYTE('255', 'de-DE')", (byte)255);
         }
 
         [Fact]
@@ -416,12 +410,16 @@ namespace NQuery.Tests.Symbols
         {
             AssertEvaluatesTo("TO_CHAR(32)", ' ');
             AssertEvaluatesTo("TO_CHAR(' ')", ' ');
+
+            AssertEvaluatesTo("TO_CHAR('ß', 'de-DE')", 'ß');
         }
 
         [Fact]
         public void BuiltInFunctions_ToDateTime()
         {
             AssertEvaluatesTo("TO_DATETIME('2015-12-31')", new DateTime(2015, 12, 31));
+            AssertEvaluatesTo("TO_DATETIME('01/02/2015', 'en-US')", new DateTime(2015, 1, 2));
+            AssertEvaluatesTo("TO_DATETIME('01/02/2015', 'en-AU')", new DateTime(2015, 2, 1));
         }
 
         [Fact]
@@ -434,6 +432,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_DECIMAL('-123.456')", -123.456m);
             AssertEvaluatesTo("TO_DECIMAL('0')", 0m);
             AssertEvaluatesTo("TO_DECIMAL('123.456')", 123.456m);
+
+            AssertEvaluatesTo("TO_DECIMAL('-123,456', 'de-DE')", -123.456m);
+            AssertEvaluatesTo("TO_DECIMAL('0,0', 'de-DE')", 0m);
+            AssertEvaluatesTo("TO_DECIMAL('123,456', 'de-DE')", 123.456m);
         }
 
         [Fact]
@@ -446,6 +448,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_DOUBLE('0')", 0d);
             AssertEvaluatesTo("TO_DOUBLE('123e4')", 123e4d);
             AssertEvaluatesTo("TO_DOUBLE('123e-4')", 123e-4d);
+
+            AssertEvaluatesTo("TO_DOUBLE('-123,456', 'de-DE')", -123.456d);
+            AssertEvaluatesTo("TO_DOUBLE('0,0', 'de-DE')", 0d);
+            AssertEvaluatesTo("TO_DOUBLE('123,456', 'de-DE')", 123.456d);
         }
 
         [Fact]
@@ -458,6 +464,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_INT16('-32000')", (short)-32000);
             AssertEvaluatesTo("TO_INT16('0')", (short)0);
             AssertEvaluatesTo("TO_INT16('32000')", (short)32000);
+
+            AssertEvaluatesTo("TO_INT16('-32000', 'de-DE')", (short)-32000);
+            AssertEvaluatesTo("TO_INT16('0', 'de-DE')", (short)0);
+            AssertEvaluatesTo("TO_INT16('32000', 'de-DE')", (short)32000);
         }
 
         [Fact]
@@ -470,6 +480,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_INT32('-123456789')", -123456789);
             AssertEvaluatesTo("TO_INT32('0')", 0);
             AssertEvaluatesTo("TO_INT32('123456789')", 123456789);
+
+            AssertEvaluatesTo("TO_INT32('-123456789', 'de-DE')", -123456789);
+            AssertEvaluatesTo("TO_INT32('0', 'de-DE')", 0);
+            AssertEvaluatesTo("TO_INT32('123456789', 'de-DE')", 123456789);
         }
 
         [Fact]
@@ -482,6 +496,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_INT64('-12345678912')", -12345678912);
             AssertEvaluatesTo("TO_INT64('0')", (long)0);
             AssertEvaluatesTo("TO_INT64('12345678912')", 12345678912);
+
+            AssertEvaluatesTo("TO_INT64('-12345678912', 'de-DE')", -12345678912);
+            AssertEvaluatesTo("TO_INT64('0', 'de-DE')", (long)0);
+            AssertEvaluatesTo("TO_INT64('12345678912', 'de-DE')", 12345678912);
         }
 
         [Fact]
@@ -494,6 +512,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_SBYTE('-127')", (sbyte)-127);
             AssertEvaluatesTo("TO_SBYTE('0')", (sbyte)0);
             AssertEvaluatesTo("TO_SBYTE('127')", (sbyte)127);
+
+            AssertEvaluatesTo("TO_SBYTE('-127', 'de-DE')", (sbyte)-127);
+            AssertEvaluatesTo("TO_SBYTE('0', 'de-DE')", (sbyte)0);
+            AssertEvaluatesTo("TO_SBYTE('127', 'de-DE')", (sbyte)127);
         }
 
         [Fact]
@@ -506,6 +528,10 @@ namespace NQuery.Tests.Symbols
             AssertEvaluatesTo("TO_SINGLE('0')", 0f);
             AssertEvaluatesTo("TO_SINGLE('123e4')", 123e4f);
             AssertEvaluatesTo("TO_SINGLE('123e-4')", 123e-4f);
+
+            AssertEvaluatesTo("TO_SINGLE('-123,456', 'de-DE')", -123.456f);
+            AssertEvaluatesTo("TO_SINGLE('0,0', 'de-DE')", 0f);
+            AssertEvaluatesTo("TO_SINGLE('123,456', 'de-DE')", 123.456f);
         }
 
         [Fact]
@@ -516,6 +542,9 @@ namespace NQuery.Tests.Symbols
 
             AssertEvaluatesTo("TO_STRING(FALSE)", "False");
             AssertEvaluatesTo("TO_STRING(TRUE)", "True");
+
+            AssertEvaluatesTo("TO_STRING(5.1)", "5.1");
+            AssertEvaluatesTo("TO_STRING(5.1, 'de-DE')", "5,1");
         }
 
         [Fact]
@@ -526,6 +555,9 @@ namespace NQuery.Tests.Symbols
 
             AssertEvaluatesTo("TO_UINT16('0')", (ushort)0);
             AssertEvaluatesTo("TO_UINT16('65000')", (ushort)65000);
+
+            AssertEvaluatesTo("TO_UINT16('0', 'de-DE')", (ushort)0);
+            AssertEvaluatesTo("TO_UINT16('65000', 'de-DE')", (ushort)65000);
         }
 
         [Fact]
@@ -536,6 +568,9 @@ namespace NQuery.Tests.Symbols
 
             AssertEvaluatesTo("TO_UINT32('0')", (uint)0);
             AssertEvaluatesTo("TO_UINT32('4123456789')", 4123456789);
+
+            AssertEvaluatesTo("TO_UINT32('0', 'de-DE')", (uint)0);
+            AssertEvaluatesTo("TO_UINT32('4123456789', 'de-DE')", 4123456789);
         }
 
         [Fact]
@@ -546,6 +581,9 @@ namespace NQuery.Tests.Symbols
 
             AssertEvaluatesTo("TO_UINT64('0')", (ulong)0);
             AssertEvaluatesTo("TO_UINT64('9999999999123456789')", 9999999999123456789);
+
+            AssertEvaluatesTo("TO_UINT64('0', 'de-DE')", (ulong)0);
+            AssertEvaluatesTo("TO_UINT64('9999999999123456789', 'de-DE')", 9999999999123456789);
         }
 
         [Fact]
@@ -558,6 +596,8 @@ namespace NQuery.Tests.Symbols
         public void BuiltInFunctions_Upper()
         {
             AssertEvaluatesTo("UPPER('Hello')", "HELLO");
+            AssertEvaluatesTo("UPPER('i')", "I");
+            AssertEvaluatesTo("UPPER('i', 'tr-TR')", "\u0130");
         }
 
         [Fact]

--- a/src/NQuery/Symbols/BuiltInFunctions.cs
+++ b/src/NQuery/Symbols/BuiltInFunctions.cs
@@ -13,20 +13,35 @@ namespace NQuery.Symbols
             return new FunctionSymbol[]
             {
                 new FunctionSymbol<object, bool>(@"TO_BOOLEAN", @"value", ToBoolean),
+                new FunctionSymbol<object, string, bool>(@"TO_BOOLEAN", @"value", @"culture", ToBoolean),
                 new FunctionSymbol<object, byte>(@"TO_BYTE", @"value", ToByte),
+                new FunctionSymbol<object, string, byte>(@"TO_BYTE", @"value", @"culture", ToByte),
                 new FunctionSymbol<object, char>(@"TO_CHAR", @"value", ToChar),
+                new FunctionSymbol<object, string, char>(@"TO_CHAR", @"value", @"culture", ToChar),
                 new FunctionSymbol<object, DateTime>(@"TO_DATETIME", @"value", ToDateTime),
+                new FunctionSymbol<object, string, DateTime>(@"TO_DATETIME", @"value", @"culture", ToDateTime),
                 new FunctionSymbol<object, decimal>(@"TO_DECIMAL", @"value", ToDecimal),
+                new FunctionSymbol<object, string, decimal>(@"TO_DECIMAL", @"value", @"culture", ToDecimal),
                 new FunctionSymbol<object, double>(@"TO_DOUBLE", @"value", ToDouble),
+                new FunctionSymbol<object, string, double>(@"TO_DOUBLE", @"value", @"culture", ToDouble),
                 new FunctionSymbol<object, short>(@"TO_INT16", @"value", ToInt16),
+                new FunctionSymbol<object, string, short>(@"TO_INT16", @"value", @"culture", ToInt16),
                 new FunctionSymbol<object, int>(@"TO_INT32", @"value", ToInt32),
+                new FunctionSymbol<object, string, int>(@"TO_INT32", @"value", @"culture", ToInt32),
                 new FunctionSymbol<object, long>(@"TO_INT64", @"value", ToInt64),
+                new FunctionSymbol<object, string, long>(@"TO_INT64", @"value", @"culture", ToInt64),
                 new FunctionSymbol<object, sbyte>(@"TO_SBYTE", @"value", ToSByte),
+                new FunctionSymbol<object, string, sbyte>(@"TO_SBYTE", @"value", @"culture", ToSByte),
                 new FunctionSymbol<object, float>(@"TO_SINGLE", @"value", ToSingle),
+                new FunctionSymbol<object, string, float>(@"TO_SINGLE", @"value", @"culture", ToSingle),
                 new FunctionSymbol<object, string>(@"TO_STRING", @"value", ToString),
+                new FunctionSymbol<object, string, string>(@"TO_STRING", @"value", @"culture", ToString),
                 new FunctionSymbol<object, ushort>(@"TO_UINT16", @"value", ToUInt16),
+                new FunctionSymbol<object, string, ushort>(@"TO_UINT16", @"value", @"culture", ToUInt16),
                 new FunctionSymbol<object, uint>(@"TO_UINT32", @"value", ToUInt32),
+                new FunctionSymbol<object, string, uint>(@"TO_UINT32", @"value", @"culture", ToUInt32),
                 new FunctionSymbol<object, ulong>(@"TO_UINT64", @"value", ToUInt64),
+                new FunctionSymbol<object, string, ulong>(@"TO_UINT64", @"value", @"culture", ToUInt64),
 
                 new FunctionSymbol<decimal, decimal>(@"ABS", @"value", Math.Abs),
                 new FunctionSymbol<double, double>(@"ABS", @"value", Math.Abs),
@@ -72,7 +87,9 @@ namespace NQuery.Symbols
                 new FunctionSymbol<string, int, int, string>(@"SUBSTRING", @"text", @"start", @"length", Substring),
                 new FunctionSymbol<string, int, string>(@"SUBSTRING", @"text", @"start", Substring),
                 new FunctionSymbol<string, string>(@"UPPER", @"text", Upper),
+                new FunctionSymbol<string, string, string>(@"UPPER", @"text", @"culture", Upper),
                 new FunctionSymbol<string, string>(@"LOWER", @"text", Lower),
+                new FunctionSymbol<string, string, string>(@"LOWER", @"text", @"culture", Lower),
                 new FunctionSymbol<string, string>(@"TRIM", @"text", Trim),
                 new FunctionSymbol<string, string>(@"LTRIM", @"text", LTrim),
                 new FunctionSymbol<string, string>(@"RTRIM", @"text", RTrim),
@@ -82,6 +99,7 @@ namespace NQuery.Symbols
                 new FunctionSymbol<string, string>(@"REGEX_ESCAPE", @"text", RegexEscape),
                 new FunctionSymbol<string, string>(@"REGEX_UNESCAPE", @"text", RegexUnescape),
                 new FunctionSymbol<object, string, string>(@"FORMAT", @"value", @"format", Format),
+                new FunctionSymbol<object, string, string, string>(@"FORMAT", @"value", @"format", @"culture", Format),
                 new FunctionSymbol<string, int, string>(@"REPLICATE", @"text", @"count", Replicate),
                 new FunctionSymbol<string, string>(@"REVERSE", @"text", Reverse),
                 new FunctionSymbol<string, int, string>(@"LEFT", @"text", @"numberOfChars", Left),
@@ -106,12 +124,28 @@ namespace NQuery.Symbols
             return Convert.ToBoolean(value, CultureInfo.InvariantCulture);
         }
 
+        private static bool ToBoolean(object value, string culture)
+        {
+            if (value is null)
+                return false;
+
+            return Convert.ToBoolean(value, GetCultureInfo(culture));
+        }
+
         private static byte ToByte(object value)
         {
             if (value is null)
                 return 0;
 
             return Convert.ToByte(value, CultureInfo.InvariantCulture);
+        }
+
+        private static byte ToByte(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToByte(value, GetCultureInfo(culture));
         }
 
         private static char ToChar(object value)
@@ -122,12 +156,28 @@ namespace NQuery.Symbols
             return Convert.ToChar(value, CultureInfo.InvariantCulture);
         }
 
+        private static char ToChar(object value, string culture)
+        {
+            if (value is null)
+                return (char)0;
+
+            return Convert.ToChar(value, GetCultureInfo(culture));
+        }
+
         private static DateTime ToDateTime(object value)
         {
             if (value is null)
                 return DateTime.MinValue;
 
             return Convert.ToDateTime(value, CultureInfo.InvariantCulture);
+        }
+
+        private static DateTime ToDateTime(object value, string culture)
+        {
+            if (value is null)
+                return DateTime.MinValue;
+
+            return Convert.ToDateTime(value, GetCultureInfo(culture));
         }
 
         private static decimal ToDecimal(object value)
@@ -138,12 +188,28 @@ namespace NQuery.Symbols
             return Convert.ToDecimal(value, CultureInfo.InvariantCulture);
         }
 
+        private static decimal ToDecimal(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToDecimal(value, GetCultureInfo(culture));
+        }
+
         private static double ToDouble(object value)
         {
             if (value is null)
                 return 0;
 
             return Convert.ToDouble(value, CultureInfo.InvariantCulture);
+        }
+
+        private static double ToDouble(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToDouble(value, GetCultureInfo(culture));
         }
 
         private static short ToInt16(object value)
@@ -154,12 +220,28 @@ namespace NQuery.Symbols
             return Convert.ToInt16(value, CultureInfo.InvariantCulture);
         }
 
+        private static short ToInt16(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToInt16(value, GetCultureInfo(culture));
+        }
+
         private static int ToInt32(object value)
         {
             if (value is null)
                 return 0;
 
             return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        private static int ToInt32(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToInt32(value, GetCultureInfo(culture));
         }
 
         private static long ToInt64(object value)
@@ -170,12 +252,28 @@ namespace NQuery.Symbols
             return Convert.ToInt64(value, CultureInfo.InvariantCulture);
         }
 
+        private static long ToInt64(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToInt64(value, GetCultureInfo(culture));
+        }
+
         private static sbyte ToSByte(object value)
         {
             if (value is null)
                 return 0;
 
             return Convert.ToSByte(value, CultureInfo.InvariantCulture);
+        }
+
+        private static sbyte ToSByte(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToSByte(value, GetCultureInfo(culture));
         }
 
         private static float ToSingle(object value)
@@ -186,12 +284,28 @@ namespace NQuery.Symbols
             return Convert.ToSingle(value, CultureInfo.InvariantCulture);
         }
 
+        private static float ToSingle(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToSingle(value, GetCultureInfo(culture));
+        }
+
         private static string ToString(object value)
         {
             if (value is null)
                 return null;
 
             return Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+
+        private static string ToString(object value, string culture)
+        {
+            if (value is null)
+                return null;
+
+            return Convert.ToString(value, GetCultureInfo(culture));
         }
 
         private static ushort ToUInt16(object value)
@@ -202,6 +316,14 @@ namespace NQuery.Symbols
             return Convert.ToUInt16(value, CultureInfo.InvariantCulture);
         }
 
+        private static ushort ToUInt16(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToUInt16(value, GetCultureInfo(culture));
+        }
+
         private static uint ToUInt32(object value)
         {
             if (value is null)
@@ -210,12 +332,28 @@ namespace NQuery.Symbols
             return Convert.ToUInt32(value, CultureInfo.InvariantCulture);
         }
 
+        private static uint ToUInt32(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToUInt32(value, GetCultureInfo(culture));
+        }
+
         private static ulong ToUInt64(object value)
         {
             if (value is null)
                 return 0;
 
             return Convert.ToUInt64(value, CultureInfo.InvariantCulture);
+        }
+
+        private static ulong ToUInt64(object value, string culture)
+        {
+            if (value is null)
+                return 0;
+
+            return Convert.ToUInt64(value, GetCultureInfo(culture));
         }
 
         private static double Round(double v)
@@ -295,9 +433,19 @@ namespace NQuery.Symbols
             return text?.ToUpper(CultureInfo.InvariantCulture);
         }
 
+        private static string Upper(string text, string culture)
+        {
+            return text?.ToUpper(GetCultureInfo(culture));
+        }
+
         private static string Lower(string text)
         {
             return text?.ToLower(CultureInfo.InvariantCulture);
+        }
+
+        private static string Lower(string text, string culture)
+        {
+            return text?.ToLower(GetCultureInfo(culture));
         }
 
         private static string Trim(string text)
@@ -357,8 +505,18 @@ namespace NQuery.Symbols
 
         private static string Format(object value, string format)
         {
+            return Format(value, format, CultureInfo.InvariantCulture);
+        }
+
+        private static string Format(object value, string format, string culture)
+        {
+            return Format(value, format, GetCultureInfo(culture));
+        }
+
+        private static string Format(object value, string format, IFormatProvider formatProvider)
+        {
             var embeddedFormatString = string.Format(CultureInfo.InvariantCulture, @"{{0:{0}}}", format);
-            return string.Format(CultureInfo.InvariantCulture, embeddedFormatString, value);
+            return string.Format(formatProvider, embeddedFormatString, value);
         }
 
         private static string Replicate(string text, int count)
@@ -446,6 +604,13 @@ namespace NQuery.Symbols
         private static int GetYear(DateTime dateTime)
         {
             return dateTime.Year;
+        }
+
+        private static CultureInfo GetCultureInfo(string culture)
+        {
+            ArgumentNullException.ThrowIfNull(culture);
+
+            return CultureInfo.GetCultureInfo(culture);
         }
     }
 }

--- a/src/NQuery/Symbols/BuiltInFunctions.cs
+++ b/src/NQuery/Symbols/BuiltInFunctions.cs
@@ -549,7 +549,7 @@ namespace NQuery.Symbols
             if (numberOfChars > text.Length)
                 numberOfChars = text.Length;
 
-            return text.Substring(0, numberOfChars);
+            return text[..numberOfChars];
         }
 
         private static string Right(string text, int numberOfChars)
@@ -560,7 +560,7 @@ namespace NQuery.Symbols
             if (numberOfChars > text.Length)
                 numberOfChars = text.Length;
 
-            return text.Substring(text.Length - numberOfChars, numberOfChars);
+            return text[^numberOfChars..];
         }
 
         private static string Space(int numberOfSpaces)
@@ -588,7 +588,7 @@ namespace NQuery.Symbols
 
         private static DateTime GetUtcDate()
         {
-            return DateTime.Now.ToUniversalTime();
+            return DateTime.UtcNow;
         }
 
         private static int GetDay(DateTime dateTime)

--- a/src/NQuery/Symbols/BuiltInFunctions.cs
+++ b/src/NQuery/Symbols/BuiltInFunctions.cs
@@ -262,7 +262,7 @@ namespace NQuery.Symbols
             if (chars.Length == 0 || text.Length == 0)
                 return 0;
 
-            return text.IndexOf(chars, StringComparison.CurrentCulture) + 1;
+            return text.IndexOf(chars, StringComparison.InvariantCulture) + 1;
         }
 
         private static string Substring(string text, int start, int length)
@@ -292,12 +292,12 @@ namespace NQuery.Symbols
 
         private static string Upper(string text)
         {
-            return text?.ToUpper(CultureInfo.CurrentCulture);
+            return text?.ToUpper(CultureInfo.InvariantCulture);
         }
 
         private static string Lower(string text)
         {
-            return text?.ToLower(CultureInfo.CurrentCulture);
+            return text?.ToLower(CultureInfo.InvariantCulture);
         }
 
         private static string Trim(string text)
@@ -358,7 +358,7 @@ namespace NQuery.Symbols
         private static string Format(object value, string format)
         {
             var embeddedFormatString = string.Format(CultureInfo.InvariantCulture, @"{{0:{0}}}", format);
-            return string.Format(CultureInfo.CurrentCulture, embeddedFormatString, value);
+            return string.Format(CultureInfo.InvariantCulture, embeddedFormatString, value);
         }
 
         private static string Replicate(string text, int count)


### PR DESCRIPTION
Here's a proposal for the culture-dependent built-in function discussion in #24.

First, *all* built-in functions should be invariant, including LOWER, UPPER, CHARINDEX, and FORMAT.

Second, new overloads for all culture-dependent function implementations allow users to request specific cultures explicitly. This even allows processing of input where some variable or table column data flows through the system in a different format than others do. Sample usage: `FORMAT(5, 'e', 'de-DE')` or `TO_DECIMAL('5,0', 'de-DE')`

Fixes #24.