### PR TITLE
Fix `async void` usages to follow guidelines, and fix two bugs along the way

### DIFF
--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySemanticClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySemanticClassifier.cs
@@ -21,15 +21,15 @@ namespace NQuery.Authoring.ActiproWpf.Classification
                 return;
 
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
-        private async void UpdateTags()
+        private async void UpdateTagsAsync()
         {
             var document = _workspace.CurrentDocument;
             var semanticModel = await document.GetSemanticModelAsync();

--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySemanticClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySemanticClassifier.cs
@@ -12,7 +12,7 @@ namespace NQuery.Authoring.ActiproWpf.Classification
         private readonly Workspace _workspace;
 
         public NQuerySemanticClassifier(ICodeDocument document)
-            : base(typeof(NQuerySemanticClassifier).Name, null, document, true)
+            : base(nameof(NQuerySemanticClassifier), null, document, true)
         {
             _classificationTypes = document.Language.GetService<INQueryClassificationTypes>();
 

--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySyntacticClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySyntacticClassifier.cs
@@ -12,7 +12,7 @@ namespace NQuery.Authoring.ActiproWpf.Classification
         private readonly INQueryClassificationTypes _classificationTypes;
 
         public NQuerySyntacticClassifier(ICodeDocument document)
-            : base(typeof(NQuerySyntacticClassifier).Name, null, document, true)
+            : base(nameof(NQuerySyntacticClassifier), null, document, true)
         {
             _classificationTypes = document.Language.GetService<INQueryClassificationTypes>();
             document.ParseDataChanged += DocumentOnParseDataChanged;

--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySyntacticClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQuerySyntacticClassifier.cs
@@ -16,15 +16,15 @@ namespace NQuery.Authoring.ActiproWpf.Classification
         {
             _classificationTypes = document.Language.GetService<INQueryClassificationTypes>();
             document.ParseDataChanged += DocumentOnParseDataChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void DocumentOnParseDataChanged(object sender, ParseDataPropertyChangedEventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
-        private async void UpdateTags()
+        private async void UpdateTagsAsync()
         {
             var document = Document.GetDocument();
             var syntaxTree = await document.GetSyntaxTreeAsync();

--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
@@ -15,7 +15,7 @@ namespace NQuery.Authoring.ActiproWpf.Classification
         private readonly Workspace _workspace;
 
         public NQueryUnnecessaryCodeClassifier(ICodeDocument document)
-            : base(typeof(NQueryUnnecessaryCodeClassifier).Name, null, document, true)
+            : base(nameof(NQueryUnnecessaryCodeClassifier), null, document, true)
         {
             _classificationTypes = document.Language.GetService<INQueryClassificationTypes>();
 

--- a/src/NQuery.Authoring.ActiproWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
@@ -24,15 +24,15 @@ namespace NQuery.Authoring.ActiproWpf.Classification
                 return;
 
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
-        private async void UpdateTags()
+        private async void UpdateTagsAsync()
         {
             var document = _workspace.CurrentDocument;
             var semanticModel = await document.GetSemanticModelAsync();

--- a/src/NQuery.Authoring.ActiproWpf/Margins/NQueryEditorViewCodeActionMargin.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Margins/NQueryEditorViewCodeActionMargin.cs
@@ -71,20 +71,20 @@ namespace NQuery.Authoring.ActiproWpf.Margins
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
         private void ViewOnSelectionChanged(object sender, EditorViewSelectionEventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
         private void ViewOnTextAreaLayout(object sender, TextViewTextAreaLayoutEventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
-        private async void UpdateGlyph()
+        private async void UpdateGlyphAsync()
         {
             var snapshot = _view.SyntaxEditor.GetDocumentView();
             var document = snapshot.Document;

--- a/src/NQuery.Authoring.ActiproWpf/Selection/ExtendSelectionAction.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Selection/ExtendSelectionAction.cs
@@ -20,7 +20,7 @@ namespace NQuery.Authoring.ActiproWpf.Selection
 
         public override void Execute(IEditorView view)
         {
-            ExtendSelection(view);
+            ExtendSelectionAsync(view);
         }
     }
 }

--- a/src/NQuery.Authoring.ActiproWpf/Selection/SelectionAction.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Selection/SelectionAction.cs
@@ -40,7 +40,7 @@ namespace NQuery.Authoring.ActiproWpf.Selection
                     _selectionStack.Clear();
             }
 
-            public async void ExtendSelection()
+            public async Task ExtendSelectionAsync()
             {
                 var snapshot = _editorView.SyntaxEditor.GetDocumentView();
                 var syntaxTree = await snapshot.Document.GetSyntaxTreeAsync();
@@ -90,10 +90,10 @@ namespace NQuery.Authoring.ActiproWpf.Selection
             return value;
         }
 
-        protected static void ExtendSelection(ITextView textView)
+        protected static void ExtendSelectionAsync(ITextView textView)
         {
             var selectionHandler = GetSelectionHandler(textView);
-            selectionHandler?.ExtendSelection();
+            selectionHandler?.ExtendSelectionAsync();
         }
 
         protected static void ShrinkSelection(ITextView textView)

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticErrorSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticErrorSquiggleClassifier.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
                 return;
 
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         protected override async Task<(SourceText Text, IEnumerable<Diagnostic> Diagnostics)> GetDiagnosticsAsync()

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticErrorSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticErrorSquiggleClassifier.cs
@@ -9,7 +9,7 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
         private readonly Workspace _workspace;
 
         public NQuerySemanticErrorSquiggleClassifier(ICodeDocument document)
-            : base(ClassificationTypes.CompilerError, typeof(NQuerySemanticErrorSquiggleClassifier).Name, null, document, true)
+            : base(ClassificationTypes.CompilerError, nameof(NQuerySemanticErrorSquiggleClassifier), null, document, true)
         {
             _workspace = document.GetWorkspace();
             if (_workspace is null)

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticIssueSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticIssueSquiggleClassifier.cs
@@ -19,15 +19,15 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
                 return;
 
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
-        private async void UpdateTags()
+        private async void UpdateTagsAsync()
         {
             var document = _workspace.CurrentDocument;
             var semanticModel = await document.GetSemanticModelAsync();

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticIssueSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySemanticIssueSquiggleClassifier.cs
@@ -12,7 +12,7 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
         private readonly Workspace _workspace;
 
         public NQuerySemanticIssueSquiggleClassifier(ICodeDocument document)
-            : base(typeof(NQuerySemanticIssueSquiggleClassifier).Name, null, document, true)
+            : base(nameof(NQuerySemanticIssueSquiggleClassifier), null, document, true)
         {
             _workspace = document.GetWorkspace();
             if (_workspace is null)

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySquiggleClassifier.cs
@@ -18,7 +18,7 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
             _classificationType = classificationType;
         }
 
-        protected async void UpdateTags()
+        protected async void UpdateTagsAsync()
         {
             var versionAndDiagnostics = await GetDiagnosticsAsync();
             var text = versionAndDiagnostics.Text;

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySyntaxErrorSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySyntaxErrorSquiggleClassifier.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
                 return;
 
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateTags();
+            UpdateTagsAsync();
         }
 
         protected override async Task<(SourceText Text, IEnumerable<Diagnostic> Diagnostics)> GetDiagnosticsAsync()

--- a/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySyntaxErrorSquiggleClassifier.cs
+++ b/src/NQuery.Authoring.ActiproWpf/Squiggles/NQuerySyntaxErrorSquiggleClassifier.cs
@@ -9,7 +9,7 @@ namespace NQuery.Authoring.ActiproWpf.Squiggles
         private readonly Workspace _workspace;
 
         public NQuerySyntaxErrorSquiggleClassifier(ICodeDocument document)
-            : base(ClassificationTypes.SyntaxError, typeof(NQuerySemanticErrorSquiggleClassifier).Name, null, document, true)
+            : base(ClassificationTypes.SyntaxError, nameof(NQuerySemanticErrorSquiggleClassifier), null, document, true)
         {
             _workspace = document.GetWorkspace();
             if (_workspace is null)

--- a/src/NQuery.Authoring.VSEditorWpf/AsyncTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/AsyncTagger.cs
@@ -11,7 +11,7 @@ namespace NQuery.Authoring.VSEditorWpf
         private ImmutableArray<TRawTag> _rawTags = ImmutableArray<TRawTag>.Empty;
         private ITextSnapshot _rawTagsSnapshot;
 
-        protected async void InvalidateTags()
+        protected async void InvalidateTagsAsync()
         {
             var (snapshot, rawTags) = await GetRawTagsAsync();
             _rawTagsSnapshot = snapshot;

--- a/src/NQuery.Authoring.VSEditorWpf/BraceMatching/NQueryBraceTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/BraceMatching/NQueryBraceTagger.cs
@@ -20,17 +20,17 @@ namespace NQuery.Authoring.VSEditorWpf.BraceMatching
             _braceMatcherService = braceMatcherService;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
             _textView.Caret.PositionChanged += CaretOnPositionChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void CaretOnPositionChanged(object sender, CaretPositionChangedEventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<SnapshotSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Classification/NQuerySemanticClassifier.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Classification/NQuerySemanticClassifier.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.VSEditorWpf.Classification
             _classificationService = classificationService;
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<SemanticClassificationSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Classification/NQuerySyntaxClassifier.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Classification/NQuerySyntaxClassifier.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.VSEditorWpf.Classification
             _classificationService = classificationService;
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<SyntaxClassificationSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Classification/NQueryUnnecessaryCodeClassifier.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.VSEditorWpf.Classification
             _classificationService = classificationService;
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<TextSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Commenting/CommentOperations.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Commenting/CommentOperations.cs
@@ -18,12 +18,12 @@ namespace NQuery.Authoring.VSEditorWpf.Commenting
             _textBufferUndoManager = textBufferUndoManager;
         }
 
-        public async void ToggleSingleLineComment()
+        public async void ToggleSingleLineCommentAsync()
         {
             await ToggleComment(Commenter.ToggleSingleLineComment);
         }
 
-        public async void ToggleMultiLineComment()
+        public async void ToggleMultiLineCommentAsync()
         {
             await ToggleComment(Commenter.ToggleMultiLineComment);
         }

--- a/src/NQuery.Authoring.VSEditorWpf/Commenting/ICommentOperations.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Commenting/ICommentOperations.cs
@@ -2,7 +2,7 @@
 {
     public interface ICommentOperations
     {
-        void ToggleSingleLineComment();
-        void ToggleMultiLineComment();
+        void ToggleSingleLineCommentAsync();
+        void ToggleMultiLineCommentAsync();
     }
 }

--- a/src/NQuery.Authoring.VSEditorWpf/Completion/CompletionModelManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Completion/CompletionModelManager.cs
@@ -44,15 +44,15 @@ namespace NQuery.Authoring.VSEditorWpf.Completion
                    c == ')';
         }
 
-        public void HandleTextInput(string text)
+        public async Task HandleTextInputAsync(string text)
         {
             if (_session is null && text.Any(IsTriggerChar))
             {
-                TriggerCompletion(false);
+                await TriggerCompletionAsync(false);
             }
             else if (_session is not null)
             {
-                UpdateModel();
+                await UpdateModelAsync();
             }
         }
 
@@ -62,21 +62,21 @@ namespace NQuery.Authoring.VSEditorWpf.Completion
                 Commit();
         }
 
-        private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
+        private async void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
             if (_session is not null)
-                UpdateModel();
+                await UpdateModelAsync();
         }
 
-        public void TriggerCompletion(bool autoComplete)
+        public async Task TriggerCompletionAsync(bool autoComplete)
         {
             if (_session is not null)
                 _session.Dismiss();
             else
-                UpdateModel();
+                await UpdateModelAsync();
         }
 
-        private async void UpdateModel()
+        private async Task UpdateModelAsync()
         {
             var documentView = _textView.GetDocumentView();
             var position = documentView.Position;

--- a/src/NQuery.Authoring.VSEditorWpf/Completion/ICompletionModelManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Completion/ICompletionModelManager.cs
@@ -4,9 +4,9 @@ namespace NQuery.Authoring.VSEditorWpf.Completion
 {
     public interface ICompletionModelManager
     {
-        void HandleTextInput(string text);
+        Task HandleTextInputAsync(string text);
         void HandlePreviewTextInput(string text);
-        void TriggerCompletion(bool autoComplete);
+        Task TriggerCompletionAsync(bool autoComplete);
         bool Commit();
 
         CompletionModel Model { get; }

--- a/src/NQuery.Authoring.VSEditorWpf/Highlighting/NQueryHighlightingTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Highlighting/NQueryHighlightingTagger.cs
@@ -21,17 +21,17 @@ namespace NQuery.Authoring.VSEditorWpf.Highlighting
             _textView = textView;
             _highlighters = highlighters;
             _textView.Caret.PositionChanged += CaretOnPositionChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void CaretOnPositionChanged(object sender, CaretPositionChangedEventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<SnapshotSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Margins/NQueryCodeActionsMargin.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Margins/NQueryCodeActionsMargin.cs
@@ -81,17 +81,17 @@ namespace NQuery.Authoring.VSEditorWpf.Margins
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
         private void CaretOnPositionChanged(object sender, CaretPositionChangedEventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
         private void TextViewOnLayoutChanged(object sender, TextViewLayoutChangedEventArgs e)
         {
-            UpdateGlyph();
+            UpdateGlyphAsync();
         }
 
         private void TextViewOnZoomLevelChanged(object sender, ZoomLevelChangedEventArgs e)
@@ -99,7 +99,7 @@ namespace NQuery.Authoring.VSEditorWpf.Margins
             LayoutTransform = e.ZoomTransform;
         }
 
-        private async void UpdateGlyph()
+        private async void UpdateGlyphAsync()
         {
             var textView = _textViewHost.TextView;
             var documentView = textView.GetDocumentView();

--- a/src/NQuery.Authoring.VSEditorWpf/NQueryKeyProcessor.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/NQueryKeyProcessor.cs
@@ -37,11 +37,11 @@ namespace NQuery.Authoring.VSEditorWpf
             get { return true; }
         }
 
-        public override void TextInput(TextCompositionEventArgs args)
+        public override async void TextInput(TextCompositionEventArgs args)
         {
             base.TextInput(args);
-            _completionModelManager.HandleTextInput(args.Text);
-            _signatureHelpManager.HandleTextInput(args.Text);
+            await _completionModelManager.HandleTextInputAsync(args.Text);
+            await _signatureHelpManager.HandleTextInputAsync(args.Text);
         }
 
         public override void PreviewTextInput(TextCompositionEventArgs args)
@@ -63,17 +63,17 @@ namespace NQuery.Authoring.VSEditorWpf
             }
             else if (modifiers == ModifierKeys.Control && key == Key.Space)
             {
-                CompleteWord();
+                CompleteWordAsync();
                 args.Handled = true;
             }
             else if (modifiers == ModifierKeys.Control && key == Key.J)
             {
-                ListMembers();
+                ListMembersAsync();
                 args.Handled = true;
             }
             else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.Space)
             {
-                ParameterInfo();
+                ParameterInfoAsync();
                 args.Handled = true;
             }
             else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.Up)
@@ -88,12 +88,12 @@ namespace NQuery.Authoring.VSEditorWpf
             }
             else if (modifiers == (ModifierKeys.Control | ModifierKeys.Alt) && key == Key.Oem2)
             {
-                _commentOperations.ToggleSingleLineComment();
+                _commentOperations.ToggleSingleLineCommentAsync();
                 args.Handled = true;
             }
             else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.Oem2)
             {
-                _commentOperations.ToggleMultiLineComment();
+                _commentOperations.ToggleMultiLineCommentAsync();
                 args.Handled = true;
             }
             else if (modifiers == ModifierKeys.None)
@@ -129,19 +129,19 @@ namespace NQuery.Authoring.VSEditorWpf
             base.PreviewKeyDown(args);
         }
 
-        private void ListMembers()
+        private async void ListMembersAsync()
         {
-            _completionModelManager.TriggerCompletion(false);
+            await _completionModelManager.TriggerCompletionAsync(false);
         }
 
-        private void CompleteWord()
+        private async void CompleteWordAsync()
         {
-            _completionModelManager.TriggerCompletion(true);
+            await _completionModelManager.TriggerCompletionAsync(true);
         }
 
-        private void ParameterInfo()
+        private async void ParameterInfoAsync()
         {
-            _signatureHelpManager.TriggerSignatureHelp();
+            await _signatureHelpManager.TriggerSignatureHelpAsync();
         }
 
         private void NavigateToPreviousHighlight()

--- a/src/NQuery.Authoring.VSEditorWpf/Outlining/NQueryOutliningTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Outlining/NQueryOutliningTagger.cs
@@ -16,12 +16,12 @@ namespace NQuery.Authoring.VSEditorWpf.Outlining
             _workspace = workspace;
             _outliningService = outliningService;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<OutliningRegionSpan> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/QuickInfo/IQuickInfoManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/QuickInfo/IQuickInfoManager.cs
@@ -4,7 +4,7 @@ namespace NQuery.Authoring.VSEditorWpf.QuickInfo
 {
     public interface IQuickInfoManager
     {
-        void TriggerQuickInfo(int offset);
+        Task TriggerQuickInfoAsync(int offset);
 
         QuickInfoModel Model { get; }
         event EventHandler<EventArgs> ModelChanged;

--- a/src/NQuery.Authoring.VSEditorWpf/QuickInfo/NQueryQuickInfoTrigger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/QuickInfo/NQueryQuickInfoTrigger.cs
@@ -16,7 +16,7 @@ namespace NQuery.Authoring.VSEditorWpf.QuickInfo
 
         private void WpfTextViewOnMouseHover(object sender, MouseHoverEventArgs e)
         {
-            _quickInfoManager.TriggerQuickInfo(e.Position);
+            _quickInfoManager.TriggerQuickInfoAsync(e.Position);
         }
     }
 }

--- a/src/NQuery.Authoring.VSEditorWpf/QuickInfo/QuickInfoManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/QuickInfo/QuickInfoManager.cs
@@ -26,7 +26,7 @@ namespace NQuery.Authoring.VSEditorWpf.QuickInfo
             _quickInfoModelProviderService = quickInfoModelProviderService;
         }
 
-        public async void TriggerQuickInfo(int offset)
+        public async Task TriggerQuickInfoAsync(int offset)
         {
             var document = _workspace.CurrentDocument;
             var semanticModel = await document.GetSemanticModelAsync();

--- a/src/NQuery.Authoring.VSEditorWpf/Selection/INQuerySelectionProvider.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Selection/INQuerySelectionProvider.cs
@@ -2,7 +2,7 @@ namespace NQuery.Authoring.VSEditorWpf.Selection
 {
     public interface INQuerySelectionProvider
     {
-        void ExtendSelection();
+        Task ExtendSelectionAsync();
         void ShrinkSelection();
     }
 }

--- a/src/NQuery.Authoring.VSEditorWpf/Selection/NQuerySelectionProvider.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Selection/NQuerySelectionProvider.cs
@@ -23,7 +23,7 @@ namespace NQuery.Authoring.VSEditorWpf.Selection
             _textView.Selection.SelectionChanged += SelectionOnSelectionChanged;
         }
 
-        public async void ExtendSelection()
+        public async Task ExtendSelectionAsync()
         {
             var documentView = _textView.GetDocumentView();
             var document = documentView.Document;

--- a/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/ISignatureHelpManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/ISignatureHelpManager.cs
@@ -4,9 +4,9 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
 {
     public interface ISignatureHelpManager
     {
-        void HandleTextInput(string text);
+        Task HandleTextInputAsync(string text);
         void HandlePreviewTextInput(string text);
-        void TriggerSignatureHelp();
+        Task TriggerSignatureHelpAsync();
 
         SignatureHelpModel Model { get; }
         event EventHandler<EventArgs> ModelChanged;

--- a/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/SignatureHelpManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/SignatureHelpManager.cs
@@ -121,6 +121,10 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
                 return;
 
             await UpdateModelAsync();
+
+            if (_session is null)
+                return;
+
             _session.Recalculate();
             _session.Match();
         }

--- a/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/SignatureHelpManager.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/SignatureHelp/SignatureHelpManager.cs
@@ -43,12 +43,12 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
 
         private void CaretOnPositionChanged(object sender, CaretPositionChangedEventArgs e)
         {
-            UpdateSession();
+            UpdateSessionAsync();
         }
 
         private void TextBufferOnPostChanged(object sender, EventArgs e)
         {
-            UpdateSession();
+            UpdateSessionAsync();
         }
 
         private static bool IsTriggerChar(char c)
@@ -57,17 +57,17 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
                    c == ',';
         }
 
-        public void HandleTextInput(string text)
+        public async Task HandleTextInputAsync(string text)
         {
             if (_session is null && text.Any(IsTriggerChar))
-                TriggerSignatureHelp();
+                await TriggerSignatureHelpAsync();
         }
 
         public void HandlePreviewTextInput(string text)
         {
         }
 
-        public void TriggerSignatureHelp()
+        public async Task TriggerSignatureHelpAsync()
         {
             if (_session is not null)
             {
@@ -75,7 +75,7 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
             }
             else
             {
-                UpdateModel();
+                await UpdateModelAsync();
             }
         }
 
@@ -90,7 +90,7 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
             return selectedIndex;
         }
 
-        private async void UpdateModel()
+        private async Task UpdateModelAsync()
         {
             var selectedIndex = GetSelectedItemIndex();
             var documentView = _textView.GetDocumentView();
@@ -115,12 +115,12 @@ namespace NQuery.Authoring.VSEditorWpf.SignatureHelp
             Model = model;
         }
 
-        private void UpdateSession()
+        private async void UpdateSessionAsync()
         {
             if (_session is null)
                 return;
 
-            UpdateModel();
+            await UpdateModelAsync();
             _session.Recalculate();
             _session.Match();
         }

--- a/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQueryCodeIssueTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQueryCodeIssueTagger.cs
@@ -19,12 +19,12 @@ namespace NQuery.Authoring.VSEditorWpf.Squiggles
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
             _codeIssueProviderService = codeIssueProviderService;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<CodeIssue> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQuerySemanticErrorTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQuerySemanticErrorTagger.cs
@@ -12,12 +12,12 @@ namespace NQuery.Authoring.VSEditorWpf.Squiggles
         {
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<Diagnostic> RawTags)> GetRawTagsAsync()

--- a/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQuerySyntaxErrorTagger.cs
+++ b/src/NQuery.Authoring.VSEditorWpf/Squiggles/NQuerySyntaxErrorTagger.cs
@@ -12,12 +12,12 @@ namespace NQuery.Authoring.VSEditorWpf.Squiggles
         {
             _workspace = workspace;
             _workspace.CurrentDocumentChanged += WorkspaceOnCurrentDocumentChanged;
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         private void WorkspaceOnCurrentDocumentChanged(object sender, EventArgs e)
         {
-            InvalidateTags();
+            InvalidateTagsAsync();
         }
 
         protected override async Task<(ITextSnapshot Snapshot, IEnumerable<Diagnostic> RawTags)> GetRawTagsAsync()

--- a/src/NQueryViewer/MainWindow.xaml.cs
+++ b/src/NQueryViewer/MainWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace NQueryViewer
             }
 
             NewEditor();
-            UpdateTree();
+            UpdateTreeAsync();
         }
 
         private void NewEditor()
@@ -105,7 +105,7 @@ namespace NQueryViewer
             DocumentTabControl.Items.RemoveAt(DocumentTabControl.SelectedIndex);
         }
 
-        private async void ExecuteQuery()
+        private async void ExecuteQueryAsync()
         {
             var editorView = CurrentEditorView;
             if (editorView is null)
@@ -183,9 +183,9 @@ namespace NQueryViewer
 
         private void UpdateDocumentState()
         {
-            UpdateTree();
-            UpdateDiagnostics();
-            UpdateShowPlan();
+            UpdateTreeAsync();
+            UpdateDiagnosticsAsync();
+            UpdateShowPlanAsync();
             UpdateDocumentKind();
         }
 
@@ -196,7 +196,7 @@ namespace NQueryViewer
             QueryModeExpressionMenuItem.IsChecked = currentKind == DocumentKind.Expression;
         }
 
-        private async void UpdateTree()
+        private async void UpdateTreeAsync()
         {
             var isVisible = ToolsViewSyntaxMenuItem.IsChecked;
 
@@ -238,7 +238,7 @@ namespace NQueryViewer
                 CurrentEditorView.Selection = span.Value;
         }
 
-        private async void UpdateDiagnostics()
+        private async void UpdateDiagnosticsAsync()
         {
             if (CurrentEditorView is null)
             {
@@ -263,7 +263,7 @@ namespace NQueryViewer
             }
         }
 
-        private async void UpdateShowPlan()
+        private async void UpdateShowPlanAsync()
         {
             if (CurrentEditorView is null)
             {
@@ -295,7 +295,7 @@ namespace NQueryViewer
             }
             else if (e.Key == Key.F5 && e.KeyboardDevice.Modifiers == ModifierKeys.None)
             {
-                ExecuteQuery();
+                ExecuteQueryAsync();
                 e.Handled = true;
             }
             else if (e.Key == Key.L && e.KeyboardDevice.Modifiers == ModifierKeys.Control)
@@ -314,7 +314,7 @@ namespace NQueryViewer
 
         private void QueryExecuteMenuItem_OnClick(object sender, RoutedEventArgs e)
         {
-            ExecuteQuery();
+            ExecuteQueryAsync();
         }
 
         private void QueryExplainMenuItem_OnClick(object sender, RoutedEventArgs e)
@@ -336,7 +336,7 @@ namespace NQueryViewer
         {
             ToolsViewSyntaxMenuItem.IsChecked = !ToolsViewSyntaxMenuItem.IsChecked;
 
-            UpdateTree();
+            UpdateTreeAsync();
         }
 
         private async void ToolsGenerateParserTestMenuItem_OnClick(object sender, RoutedEventArgs e)

--- a/src/NQueryViewer/VSEditor/VSEditorView.xaml.cs
+++ b/src/NQueryViewer/VSEditor/VSEditorView.xaml.cs
@@ -48,7 +48,7 @@ namespace NQueryViewer.VSEditor
 
             if (modifiers == ModifierKeys.Control && key == Key.W)
             {
-                _selectionProvider.ExtendSelection();
+                _selectionProvider.ExtendSelectionAsync();
                 e.Handled = true;
             }
             else if (modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && key == Key.W)


### PR DESCRIPTION
Rename `async void` methods to have `Async` suffix and return tasks all the way up to constructors/event handlers.

In SignatureHelpManager.UpdateSessionAsync, add the missing await to UpdateModelAsync call and a check for null session after updating the model.

Fixes #55. Fixes #56.