### PR TITLE
Use invariant culture for conversions in built-in `CONCAT` aggregate

### DIFF
--- a/src/NQuery/Symbols/Aggregation/ConcatAggregateDefinition.cs
+++ b/src/NQuery/Symbols/Aggregation/ConcatAggregateDefinition.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 namespace NQuery.Symbols.Aggregation
@@ -41,7 +42,7 @@ namespace NQuery.Symbols.Aggregation
                 if (value is null)
                     return;
 
-                var strValue = value.ToString().Trim();
+                var strValue = Convert.ToString(value, CultureInfo.InvariantCulture).Trim();
 
                 if (_valueList.Contains(strValue))
                     return;

--- a/src/NQuery/Symbols/Aggregation/ConcatAggregateDefinition.cs
+++ b/src/NQuery/Symbols/Aggregation/ConcatAggregateDefinition.cs
@@ -42,7 +42,12 @@ namespace NQuery.Symbols.Aggregation
                 if (value is null)
                     return;
 
-                var strValue = Convert.ToString(value, CultureInfo.InvariantCulture).Trim();
+                var strValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+
+                if (strValue is null)
+                    return;
+
+                strValue = strValue.Trim();
 
                 if (_valueList.Contains(strValue))
                     return;


### PR DESCRIPTION
Similarly to #57, the `CONCAT` aggregate should default to invariant culture for its string conversion.

In case someone wants to use culture-specific conversion of numbers, that will still be possible with a nested conversion, so there is no reduction of functionality: `CONCAT(TO_STRING(table.NumberColumn, 'fr-fr'))`

(Also, there was a potential `NullReferenceException` as `object.ToString` is allowed to return null.)