### PR TITLE
Provide core libraries on .NET Framework 4.8.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,8 @@ jobs:
           dotnet-version: '8.0.*'
       - name: dotnet build
         run: |
-          dotnet build ${env:SLN} -c Release --nologo -o ${env:BIN}
+          dotnet build ${env:SLN} -c Release --nologo
+          dotnet pack ${env:SLN} -c Release --nologo -o ${env:BIN}
       - name: dotnet test
         run: |
           dotnet test ${env:SLN} --nologo

--- a/src/Common/ArgumentNullExceptionExtensions.cs
+++ b/src/Common/ArgumentNullExceptionExtensions.cs
@@ -1,0 +1,47 @@
+#if NETFRAMEWORK
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+#nullable enable
+
+namespace NQuery
+{
+    internal static class ArgumentNullExceptionExtensions
+    {
+        extension(ArgumentNullException)
+        {
+            public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+            {
+                if (argument is null)
+                {
+                    Throw(paramName);
+                }
+            }
+
+            [DoesNotReturn]
+            public static void Throw(string? paramName) =>
+                throw new ArgumentNullException(paramName);
+        }
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue)]
+    internal sealed class NotNullAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute;
+}
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class CallerArgumentExpressionAttribute(string parameterName) : Attribute
+    {
+        public string ParameterName { get; } = parameterName;
+    }
+}
+
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,9 +7,13 @@
     <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(MSBuildProjectName) != 'NQueryViewer' AND !$(MSBuildProjectName.EndsWith('.Tests'))">
+  <PropertyGroup Condition="$(MSBuildProjectName) == 'NQueryViewer' OR $(MSBuildProjectName.EndsWith('.Testing'))">
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsPackable)' != 'false'">
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageOutputPath>$(OutDir)</PackageOutputPath>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)..\bin</PackageOutputPath>
     <Authors>$(Company)</Authors>
     <RepositoryUrl>https://github.com/terrajobst/nquery-vnext</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
   <PropertyGroup>
     <Copyright>Copyright (c) Immo Landwerth</Copyright>
     <Company>Immo Landwerth</Company>
     <Product>NQuery</Product>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName) != 'NQueryViewer' AND !$(MSBuildProjectName.EndsWith('.Tests'))">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPackable)' != 'false'">
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageOutputPath>$(MSBuildThisFileDirectory)..\bin</PackageOutputPath>
     <Authors>$(Company)</Authors>
     <RepositoryUrl>https://github.com/terrajobst/nquery-vnext</RepositoryUrl>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,9 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)\Common\CommonAssemblyInfo.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\Common\ExceptionBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\Common\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">

--- a/src/NQuery.Data/NQuery.Data.csproj
+++ b/src/NQuery.Data/NQuery.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net481</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/NQuery.Dynamic/NQuery.Dynamic.csproj
+++ b/src/NQuery.Dynamic/NQuery.Dynamic.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net481</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/NQuery.Testing/NQuery.Testing.csproj
+++ b/src/NQuery.Testing/NQuery.Testing.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>NQuery</RootNamespace>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NQuery/NQuery.csproj
+++ b/src/NQuery/NQuery.csproj
@@ -1,12 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net481</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.141" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NQuery/Optimization/ExceptIntersectPhysicalOperatorChooser.cs
+++ b/src/NQuery/Optimization/ExceptIntersectPhysicalOperatorChooser.cs
@@ -13,7 +13,11 @@ namespace NQuery.Optimization
             var sortedValues = values.Zip(node.Comparers, (v, c) => new BoundComparedValue(v, c));
             var sortedLeft = new BoundSortRelation(true, left, sortedValues);
 
-            var valueSlots = sortedLeft.GetOutputValues().Zip(right.GetOutputValues());
+            var valueSlots = sortedLeft.GetOutputValues().Zip(right.GetOutputValues()
+#if NETFRAMEWORK
+                , (l, r) => (l, r)
+#endif
+                );
             var condition = CreatePredicate(valueSlots);
 
             var joinOperator = node.IsIntersect


### PR DESCRIPTION
The "polyfill" for `ArgumentNullException.ThrowIfNull` requires C# 14, which is included in VS 2026. Unfortunately, that is not available on GitHub Actions yet, so CI is expected to fail for now:

https://github.com/actions/runner-images/issues/13291

Closes #71 